### PR TITLE
Add hidden property in PresentationDetent

### DIFF
--- a/Sources/BottomSheet/BottomSheet.swift
+++ b/Sources/BottomSheet/BottomSheet.swift
@@ -144,7 +144,10 @@ struct SheetPlus<HContent: View, MContent: View, Background: View>: ViewModifier
         .onPreferenceChange(SheetPlusKey.self) { value in
             /// Quick hack to prevent the scrollview from resetting the height when keyboard shows up.
             /// Replace if the root cause has been located.
-            if value.detents.count == 0 { return }
+            if value.detents.count == 0 || value.selectedDetent == .hidden {
+                isPresented = false
+                return
+            }
                                                 
             sheetConfig = value
             translation = value.translation

--- a/Sources/BottomSheet/Detents/DetentDefaults.swift
+++ b/Sources/BottomSheet/Detents/DetentDefaults.swift
@@ -11,4 +11,5 @@ internal struct PresentationDetentDefaults {
     static let small: CGFloat = UIScreen.main.bounds.height * 0.2
     static let medium: CGFloat = UIScreen.main.bounds.height * 0.5
     static let large: CGFloat = UIScreen.main.bounds.height * 0.9
+    static let hidden: CGFloat = 0
 }

--- a/Sources/BottomSheet/Detents/DetentHelpers.swift
+++ b/Sources/BottomSheet/Detents/DetentHelpers.swift
@@ -20,6 +20,8 @@ internal func detentLimits(detents: Set<PresentationDetent>) -> (min: CGFloat, m
                 return PresentationDetentDefaults.medium
             case .large:
                 return PresentationDetentDefaults.large
+            case .hidden:
+                return PresentationDetentDefaults.hidden
             case .fraction(let fraction):
                 return UIScreen.main.bounds.height * fraction
             case .height(let height):

--- a/Sources/BottomSheet/Detents/Detents.swift
+++ b/Sources/BottomSheet/Detents/Detents.swift
@@ -7,11 +7,46 @@
 
 import SwiftUI
 
+/**
+ An enumeration to  represent various form of PresentationDetent
+ 
+ - `small`: A small sized bottom sheet. `.fraction(0.2)`
+ - `medium`: A medium sized bottom sheet, `.fraction(0.5)`
+ - `large`: A large sized bottom sheet. `.fraction(0.9)`
+ - `hidden`: Hide bottom sheet.
+ - `fraction`: Relative to screen height.
+ - `height`: A constant height.
+ */
+
 public enum PresentationDetent: Hashable {
+    /**
+      .fraction(0.2)
+     */
     case small
+    
+    /**
+      .fraction(0.5)
+     */
     case medium
+    
+    /**
+      .fraction(0.9)
+     */
     case large
+  
+    /**
+      Hide bottom sheet
+     */
+    case hidden
+    
+    /**
+      CGFloat 0 to 1
+     */
     case fraction(CGFloat)
+  
+    /**
+      A constant height.
+     */
     case height(CGFloat)
 
     public var size: CGFloat {
@@ -22,6 +57,8 @@ public enum PresentationDetent: Hashable {
             return PresentationDetentDefaults.medium
         case .large:
             return PresentationDetentDefaults.large
+        case .hidden:
+            return PresentationDetentDefaults.hidden
         case .fraction(let fraction):
             return min(
                 UIScreen.main.bounds.height * fraction,

--- a/Sources/BottomSheet/Preference Keys/ConfigKey.swift
+++ b/Sources/BottomSheet/Preference Keys/ConfigKey.swift
@@ -19,7 +19,7 @@ struct SheetPlusConfig: Equatable {
 }
 
 struct SheetPlusKey: PreferenceKey {
-    static var defaultValue: SheetPlusConfig = SheetPlusConfig(detents: [], selectedDetent: .constant(.height(.zero)), translation: 0)
+  static var defaultValue: SheetPlusConfig = SheetPlusConfig(detents: [], selectedDetent: .constant(.hidden), translation: 0)
     
     static func reduce(value: inout SheetPlusConfig, nextValue: () -> SheetPlusConfig) {
         /// This prevents the translation changes to be called whenever the keyboard is triggered.


### PR DESCRIPTION
Hello!

First of all, I appreciate about this repository a lot. It's my life saver.

I found two things that can be improve when I use it.

Firstly, there is no hidden(close) option. So, I used `.fraction(0)` instead, but I'm not the only one who wanted hidden option(who my colleague).
Although, Perhaps your purpose was make exactly the same thing of SwiftUI's `sheet`, but I thought it isn't intuitive.

Secondly, the `@State(or @Published) var isPresented` that is outside of `BottomSheet`, isn't change to `false` by swipe down action.
When close `BottonSheet`, `isPresented` is still `true`, and never open again next time.

So, I added the `hidden` property and changed few lines.

Please consider merging my PR if you don't mind.

Thank you once again.

ps. As my english writing skill, I have attached images that what's changed.

Before

https://github.com/Wouter125/BottomSheet/assets/17230539/5560f4de-e6cb-4ac7-a5cf-84f4bad33f75


After

https://github.com/Wouter125/BottomSheet/assets/17230539/f6167986-77a5-4012-a7f8-a5fe64f30435

